### PR TITLE
Improved Build Instructions + Vagrant Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ please do not install S2E itself, but only install **build**, **S2E** and **C++1
 The μEmu source code can be obtained from the my git repository using the following commands.
 
 ```console
- # uEmuDIR must be in your home folder (e.g., /home/user/uEmu)
- sudo apt-get install git-repo
+ export uEmuDIR=/home/user/uEmu  # uEmuDIR must be in your home folder (e.g., /home/user/uEmu)
+ sudo apt-get install git-repo   # or follow instructions at https://gerrit.googlesource.com/git-repo/
  cd $uEmuDIR
- sudo repo init -u https://github.com/MCUSec/manifest.git -b uEmu
- sudo repo sync
+ repo init -u https://github.com/MCUSec/manifest.git -b uEmu
+ repo sync
 ```
 This will set up the μEmu repositories in ``$uEmuDIR``.
 
@@ -77,7 +77,7 @@ The μEmu Makefile can be run as follows:
 ```console
     $ sudo mkdir $uEmuDIR/build
     $ cd $uEmuDIR/build
-    $ sudo make -f $uEmuDIR/Makefile install
+    $ make -f $uEmuDIR/Makefile && sudo make install
     # Go make some coffee or do whatever you want, this will take some time (approx. 60 mins on a 4-core machine)
 ```
 
@@ -92,7 +92,7 @@ To compile μEmu in debug mode, use ``make install-debug``.
 
 ```console
 cd $uEmuDIR/AFL
-sudo make
+make
 sudo make install
 ```
 
@@ -148,12 +148,13 @@ After the above command successfully finishes,  you could find the `launch-uEmu.
 After finishing (typically a few minutes), you can find log files and knowledge base (KB) file (e.g., `WYCINWYC.elf-round1-state53-tbnum1069_KB.dat`) in `s2e-last` (referring to the `s2e-out-<max>`) folder. Detail logs will be printed to `s2e-last/debug.txt` and important log information will be printed to`s2e-last/warnings.txt` . More detail about log files please refer to [S2E documents](http://s2e.systems/docs/index.html) .
 
 **NOTE**:
-1. If you find μEmu cannot be finished KB extraction with a quiet long time (e.g., more than ten minutes), typically the reason is μEmu has been stuck. You should manually abort the execution, then check the configuration file and log files to find the failure reasons, then re-configure and re-run the firmware with μEmu. Thus, we recommend user to enable debug level log information (add `--debug` in above command)  when he first time runs the firmware.
+
+1. If you find μEmu cannot be finished KB extraction with a quiet long time (e.g., more than ten minutes), typically the reason is μEmu has been stuck. You should manually abort the execution, then check the configuration file, firmware and log files to find the reason and re-configure and re-run the firmware with μEmu. Thus,  we recommend user to enable debug level log information (add `--debug` in above command)  when he first time runs the firmware.
 
 
 #### Dynamic Analysis and Fuzzing Phase:
 
-Next, you can run the firmware with learned KB for dynamic analysis.  About more detail about KB entries format please refer to [kb.md](docs/kb.md).
+Next, you can run the firmware with learned KB for dynamic analysis.  About more detail about KB entries format please refer to [kb.md](docs/KB.md).
 
 The below command is to configure μEmu for running `WYCINWYC.elf` firmware in dynamic phase with `WYCINWYC.elf-round1-state53-tbnum1069_KB` KB file and fuzzing seed file `small_document.xml`.
 
@@ -161,8 +162,7 @@ The below command is to configure μEmu for running `WYCINWYC.elf` firmware in d
 ```console
 python3 uEmu-helper.py WYCINWYC.elf WYCNINWYC.cfg -kb WYCINWYC.elf-round1-state53-tbnum1069_KB.dat -s small_document.xml
 ```
-
-Since μEmu relies on AFL for fuzzing input. Thus, you **first** need to launch AFL fuzzur via `./launch-AFL.sh` in **one** terminal to input test-cases and then launch μEmu via `./launch-uEmu.sh` in **another** terminal to consume the test-cases.
+Since μEmu relies on AFL for fuzzing input. Thus, you first need to launch AFL fuzzur via `./launch-AFL.sh` in one terminal to input test-cases and then launch μEmu via `./launch-uEmu.sh` in another terminal to consume the test-cases.
 The fuzzing results is stored in <proj_dir>/<firmware> folder. The log and KB files of addition round KB extraction phase are record in <s2e-last> folder.
 
 **NOTE**:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,26 @@ publisher = {{USENIX} Association},
 ├── uEmu-config-template.lua # template config file of μEmu and S2E plugins
 ├── library.lua              # Contains convenience functions for the uEmu-config.lua file.
 ├── uEmu-unit_tests          # uEmu unit test samples and config files
-├── uEmu-fuzzing_tests       # uEmu fuzzing test samlpes (real-world MCU firmware) and config files
-└── ptracearm.h
+├── uEmu-fuzzing_tests       # uEmu fuzzing test samples (real-world MCU firmware) and config files
+├── ptracearm.h
+├── vagrant-bootstrap.sh     # bootstrap file for vagrant box
+└── Vagrantfile              # configuration file for vagrant box
 ```
 
+## Vagrant Installation
+
+For easy setup, a vagrant file for a virtual machine with a ready-to-use build of uEmu is provided.
+After installing vagrant, the following steps are required:
+```bash
+git clone https://github.com/MCUSec/uEmu.git
+cd uEmu
+vagrant up  # this will take a while, please be patient
+vagrant ssh # connect to the virtual machine
+```
+
+Now, from inside the virtual machine, you have the contents of this repository available at `/vagrant/`.
+
+**Note**: The VM is configured to use 4 cores and 4096 MB of RAM. You can change this by modifying the Vagrant file.
 
 ## Source Code Installation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,72 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/focal64"
+  config.vm.provision :shell, path: "vagrant-bootstrap.sh", privileged: false
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+    vb.memory = "4096"
+    vb.cpus = 4
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/vagrant-bootstrap.sh
+++ b/vagrant-bootstrap.sh
@@ -1,0 +1,58 @@
+sudo apt-get update
+
+# Initial build dependencies and packages are taken from:
+#    https://github.com/S2E/s2e/blob/master/Dockerfile#L35
+sudo dpkg --add-architecture i386
+sudo apt-get update
+sudo apt-get -y install build-essential cmake wget texinfo flex bison       \
+    python-dev python3-dev python3-venv python3-distro mingw-w64 lsb-release
+
+sudo apt-get update
+sudo apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386             \
+    libboost-dev zlib1g-dev libjemalloc-dev nasm pkg-config                 \
+    libmemcached-dev libpq-dev libc6-dev-i386 binutils-dev                  \
+    libboost-system-dev libboost-serialization-dev libboost-regex-dev       \
+    libbsd-dev libpixman-1-dev                                              \
+    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev          \
+    gcc-multilib g++-multilib
+
+# Additional requirement required by clang
+sudo apt-get install libtinfo5
+
+# install git repo;
+# 20.04 does only provide it as snap package, we opt in for manual installation
+mkdir -p ~/.bin
+PATH="${HOME}/.bin:${PATH}"
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.bin/repo
+chmod a+rx ~/.bin/repo
+
+# setup env and directories
+mkdir -p uemu/build
+export uEmuDIR=$PWD/uemu
+
+cd $uEmuDIR
+~/.bin/repo init -u https://github.com/MCUSec/manifest.git -b uEmu
+~/.bin/repo sync
+
+# fix permissions
+chmod +x $uEmuDIR/s2e/libs2e/configure
+
+# get ptracearm.h
+sudo wget -P /usr/include/x86_64-linux-gnu/asm \
+    https://raw.githubusercontent.com/MCUSec/uEmu/main/ptracearm.h
+
+# start build process
+cd $uEmuDIR/build && make -f $uEmuDIR/Makefile
+sudo make -f $uEmuDIR/Makefile install
+
+cd $uEmuDIR/AFL
+make
+sudo make install
+
+# Set up environment for new connections
+echo "export uEmuDIR=$uEmuDIR" >> ~/.bashrc
+
+# Installation done, get all repositories
+cd $uEmuDIR
+git clone https://github.com/MCUSec/uEmu-unit_tests.git
+git clone https://github.com/MCUSec/uEmu-real_world_firmware.git


### PR DESCRIPTION
Heya,

I build uEmu over here and created a vagrantfile for doing so automatically. Along the way, I updated the build instructions to best practices, i.e., do not build things as root user (only `make install` requires sudo).

For the Vagrant file, I tested that the uEmu helper runs as expected and that I can run the knowledge extraction. I have not tested dynamic fuzzing yet.

Cheers,
Marius