### PR TITLE
Use ConfigParser directly instead

### DIFF
--- a/uEmu-helper.py
+++ b/uEmu-helper.py
@@ -14,7 +14,7 @@ DEFAULT_TEMPLATES_DIR = os.getcwd()
 def read_config(cfg_f, mode, cachefilename, firmwarename, debug):
     if not os.path.isfile(cfg_f):
         sys.exit("Cannot find the specified configuration file: %s" % cfg_f)
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     parser.read(cfg_f)
 
     # Prepare the target firmware lua configuration


### PR DESCRIPTION
Hi
I execute uEmu-helper.py at Vagrant environment.
After running the program, the following warning was displayed.

However, if merge this pull request, it may not work with older Python(< 3.2?).

```bash
uEmu-helper.py:17: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  parser = configparser.SafeConfigParser()
```

```bash
vagrant@ubuntu-focal:$ python3 --version
Python 3.8.10
```